### PR TITLE
remove dependency on modernizr for one single test

### DIFF
--- a/assets/js/minimal-share.js
+++ b/assets/js/minimal-share.js
@@ -14,7 +14,7 @@
         }
 
         // Show hidden mobile share links.
-        if ($this.hasClass('ms-mobile-only') && Modernizr.touchevents) {
+        if ($this.hasClass('ms-mobile-only') && (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch))) {
           $this.addClass('ms-show');
         }
 

--- a/minimal_share.libraries.yml
+++ b/minimal_share.libraries.yml
@@ -8,4 +8,3 @@ minimal-share:
   dependencies:
     - core/jquery
     - core/drupal
-    - core/modernizr


### PR DESCRIPTION
To improve frontend performance you could avoid requiring modernizr as dependency since it is used for one single test.
I just put the test directly into the minimal_share's JS
