### PR TITLE
Make Minimal Share D9 compatible #23

### DIFF
--- a/minimal_share.info.yml
+++ b/minimal_share.info.yml
@@ -2,5 +2,6 @@ name: Minimal Share
 type: module
 description: Provides minimal share buttons for several services.
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Custom
 configure: minimal_share.config


### PR DESCRIPTION
See my colleagues issue #23 
To test this locally:

1. add a new section in your composer.json's `repositories` section:
```
"repositories": {
        "drupal": {
            "type": "composer",
            "url": "https://packages.drupal.org/8",
            "exclude": ["drupal/minimal_share"]
        },
        "minimal_share": {
            "type": "package",
            "package": {
                "name": "drupal/minimal_share",
                "version": "dev-custom",
                "type": "drupal-module",
                "source": {
                    "type": "git",
                    "url": "git@github.com:miiimooo/minimal_share.git",
                    "reference": "8.x-1.x"
                }
            }
        }
..
```
2. Require package
```
composer require "drupal/minimal_share":dev-custom
```

